### PR TITLE
Fixed incorrect library argument to the linker.

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -5,7 +5,7 @@ AM_C_CPPFLAGS = -I../src
 AM_LDFLAGS = \
 		../src/cclog/libcclog.la \
 		../src/msgpack/rpc/libmsgpack-rpc.la \
-		-lmpio -msgpack
+		-lmpio -lmsgpack
 
 check_HEADERS = \
 		echo_server.h


### PR DESCRIPTION
Building the tests failed to compile on ubuntu 14.04 because -msgpack was specified
instead of -lmsgpack in the test makefile.
